### PR TITLE
Eagle servers with https or custom domains are available.

### DIFF
--- a/scripts/eagleapi/api_util.py
+++ b/scripts/eagleapi/api_util.py
@@ -8,11 +8,13 @@ def get_url_port(server_url_port=""):
     if not server_url_port or server_url_port == "":
         return None, None
     o = urlparse(server_url_port)
-    _url = f"http://{o.hostname}"
-    if o.hostname != "localhost":
+    _url = f"{o.scheme}://{o.hostname}"
+    try:
         _ip = ipaddress.ip_address(o.hostname)
         if _ip.version == 6:
-            _url = f"http://[{o.hostname}]"
+            _url = f"{o.scheme}://[{o.hostname}]"
+    except:
+        pass
     port = o.port
     return _url, port
 


### PR DESCRIPTION
Before the improvement, the method did not work correctly in the following cases.
- When the Eagle server is listening over https.
- Eagle server listening on a domain name other than localhost. This is a possible scenario when using a proxy tunnel such as Ngrok to expose an Eagle server hosted at home to the Internet. This patch will allow the SD-WebUI deployed on Paperspace to send images to the Eagle server at home via the Ngrok tunnel.